### PR TITLE
Add NexError trait and return generic from protocols

### DIFF
--- a/macros/src/nex_protocol.rs
+++ b/macros/src/nex_protocol.rs
@@ -52,7 +52,7 @@ fn create_variant_method(variant: &Variant) -> Option<proc_macro2::TokenStream> 
             &self,
             client: &mut nex_rs::client::ClientConnection,
             request: &nex_rs::rmc::RMCRequest,
-        ) -> nex_rs::result::NexResult<()> {
+        ) -> nex_rs::server::ServerResult<()> {
             let parameters = request.parameters.as_slice();
             let mut parameters_stream = no_std_io::StreamContainer::new(parameters);
 

--- a/macros/tests/nex_protocol.rs
+++ b/macros/tests/nex_protocol.rs
@@ -3,11 +3,12 @@ use nex_rs::{
     client::{ClientConnection, ClientContext},
     nex_types::ResultCode,
     packet::PacketV1,
-    result::Error,
+    result::NexError,
     rmc::RMCRequest,
     server::{BaseServer, EventHandler, Server, ServerResult},
 };
 use no_std_io::{EndianRead, EndianWrite, Writer};
+use std::fmt;
 
 #[derive(Debug, Default, EndianRead, EndianWrite)]
 pub struct AddInput {
@@ -77,7 +78,7 @@ impl EventHandler for MockServer {
     ) -> ServerResult<()> {
         Ok(())
     }
-    async fn on_error(&self, _error: Error) {}
+    async fn on_error(&self, _error: &nex_rs::result::Error) {}
 }
 
 #[async_trait::async_trait]
@@ -115,19 +116,36 @@ impl Server for MockServer {
     }
 }
 
+#[derive(Debug)]
+enum Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl NexError for Error {
+    fn error_code(&self) -> ResultCode {
+        0.into()
+    }
+}
+
 #[async_trait::async_trait]
 impl MathProtocol for MockServer {
+    type Error = Error;
+
     async fn add(
         &self,
         _client: &mut ClientConnection,
         input: AddInput,
-    ) -> Result<AddOutput, ResultCode> {
+    ) -> Result<AddOutput, Error> {
         Ok(AddOutput {
             sum: input.first + input.second,
         })
     }
 
-    async fn noop(&self, _client: &mut ClientConnection) -> Result<(), ResultCode> {
+    async fn noop(&self, _client: &mut ClientConnection) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/macros/tests/nex_protocol.rs
+++ b/macros/tests/nex_protocol.rs
@@ -3,7 +3,7 @@ use nex_rs::{
     client::{ClientConnection, ClientContext},
     nex_types::ResultCode,
     packet::PacketV1,
-    result::{Error, NexResult},
+    result::Error,
     rmc::RMCRequest,
     server::{BaseServer, EventHandler, Server, ServerResult},
 };
@@ -39,34 +39,42 @@ struct MockServer {
 
 #[async_trait::async_trait]
 impl EventHandler for MockServer {
-    async fn on_syn(&self, _client: &mut ClientConnection, _packet: &PacketV1) -> NexResult<()> {
+    async fn on_syn(&self, _client: &mut ClientConnection, _packet: &PacketV1) -> ServerResult<()> {
         Ok(())
     }
     async fn on_connect(
         &self,
         _client: &mut ClientConnection,
         _packet: &PacketV1,
-    ) -> NexResult<()> {
+    ) -> ServerResult<()> {
         Ok(())
     }
-    async fn on_data(&self, _client: &mut ClientConnection, _packet: &PacketV1) -> NexResult<()> {
+    async fn on_data(
+        &self,
+        _client: &mut ClientConnection,
+        _packet: &PacketV1,
+    ) -> ServerResult<()> {
         Ok(())
     }
     async fn on_disconnect(
         &self,
         _client: &mut ClientConnection,
         _packet: &PacketV1,
-    ) -> NexResult<()> {
+    ) -> ServerResult<()> {
         Ok(())
     }
-    async fn on_ping(&self, _client: &mut ClientConnection, _packet: &PacketV1) -> NexResult<()> {
+    async fn on_ping(
+        &self,
+        _client: &mut ClientConnection,
+        _packet: &PacketV1,
+    ) -> ServerResult<()> {
         Ok(())
     }
     async fn on_rmc_request(
         &self,
         _client: &mut ClientConnection,
         _rmc_request: &RMCRequest,
-    ) -> NexResult<()> {
+    ) -> ServerResult<()> {
         Ok(())
     }
     async fn on_error(&self, _error: Error) {}

--- a/nex-rs/src/nex_types/result_code.rs
+++ b/nex-rs/src/nex_types/result_code.rs
@@ -1,7 +1,7 @@
 use core::mem;
 use no_std_io::{EndianRead, EndianWrite, Error, ReadOutput, Writer};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ResultCode(u32);
 
 impl EndianRead for ResultCode {

--- a/nex-rs/src/result.rs
+++ b/nex-rs/src/result.rs
@@ -1,64 +1,20 @@
-use crate::{client, crypto, packet, server};
+use crate::server;
 use snafu::Snafu;
 
 #[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display(
-        "Packet error: {}",
-        error.to_string()
-    ))]
-    PacketError { error: packet::Error },
-    #[snafu(display(
-        "Crypt error: {}",
-        error.to_string()
-    ))]
-    CryptError { error: crypto::Error },
-    #[snafu(display(
-        "Client connection error: {}",
-        error.to_string()
-    ))]
-    ClientConectionError { error: client::Error },
-    #[snafu(display(
-        "Client connection error: {}",
+        "Server error: {}",
         error.to_string()
     ))]
     ServerError { error: server::Error },
-    #[snafu(display(
-        "IO Error: {}",
-        error.to_string()
-    ))]
-    IoError { error: no_std_io::Error },
     #[snafu(display("Error: {}", message))]
     Generic { message: String },
-}
-
-impl From<packet::Error> for Error {
-    fn from(error: packet::Error) -> Self {
-        Self::PacketError { error }
-    }
-}
-
-impl From<crypto::Error> for Error {
-    fn from(error: crypto::Error) -> Self {
-        Self::CryptError { error }
-    }
-}
-
-impl From<client::Error> for Error {
-    fn from(error: client::Error) -> Self {
-        Self::ClientConectionError { error }
-    }
 }
 
 impl From<server::Error> for Error {
     fn from(error: server::Error) -> Self {
         Self::ServerError { error }
-    }
-}
-
-impl From<no_std_io::Error> for Error {
-    fn from(error: no_std_io::Error) -> Self {
-        Self::IoError { error }
     }
 }
 

--- a/nex-rs/src/result/empty_error.rs
+++ b/nex-rs/src/result/empty_error.rs
@@ -2,6 +2,9 @@ use super::NexError;
 use crate::nex_types::ResultCode;
 use snafu::Snafu;
 
+/// A convenience error for nex protocol traits that won't need an error.
+/// For example, a utility trait that generates random numbers might not
+/// have a reason to error.
 #[derive(Debug, Snafu)]
 pub enum EmptyError {}
 
@@ -11,4 +14,5 @@ impl NexError for EmptyError {
     }
 }
 
+/// A convenience [Result] alias to use for nex protocol traits that won't error.
 pub type SuccessfulResult<T> = Result<T, EmptyError>;

--- a/nex-rs/src/result/empty_error.rs
+++ b/nex-rs/src/result/empty_error.rs
@@ -1,0 +1,14 @@
+use super::NexError;
+use crate::nex_types::ResultCode;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum EmptyError {}
+
+impl NexError for EmptyError {
+    fn error_code(&self) -> ResultCode {
+        0.into()
+    }
+}
+
+pub type SuccessfulResult<T> = Result<T, EmptyError>;

--- a/nex-rs/src/result/error.rs
+++ b/nex-rs/src/result/error.rs
@@ -3,6 +3,9 @@ use crate::server;
 use snafu::Snafu;
 use std::fmt::Debug;
 
+/// The top level error for anything nex related.
+/// All server errors and generic errors provided by nex protocol trait
+/// implementations will eventually bubble up to this.
 #[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
     #[snafu(display(

--- a/nex-rs/src/result/error.rs
+++ b/nex-rs/src/result/error.rs
@@ -1,6 +1,7 @@
-use crate::{nex_types::ResultCode, server};
+use super::NexError;
+use crate::server;
 use snafu::Snafu;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 #[derive(Debug, PartialEq, Snafu)]
 pub enum Error {
@@ -23,20 +24,6 @@ impl From<&str> for Error {
     fn from(message: &str) -> Self {
         Self::Generic {
             message: message.to_string(),
-        }
-    }
-}
-
-pub trait NexError: Debug + Display + Send {
-    fn error_code(&self) -> ResultCode;
-}
-
-pub type NexResult<T> = Result<T, Box<dyn NexError>>;
-
-impl From<Box<dyn NexError>> for Error {
-    fn from(error: Box<dyn NexError>) -> Self {
-        Self::Generic {
-            message: error.to_string(),
         }
     }
 }

--- a/nex-rs/src/result/mod.rs
+++ b/nex-rs/src/result/mod.rs
@@ -1,0 +1,8 @@
+mod error;
+pub use error::*;
+
+mod nex_error;
+pub use nex_error::*;
+
+mod empty_error;
+pub use empty_error::*;

--- a/nex-rs/src/result/nex_error.rs
+++ b/nex-rs/src/result/nex_error.rs
@@ -1,0 +1,8 @@
+use crate::nex_types::ResultCode;
+use std::fmt::{Debug, Display};
+
+pub trait NexError: Debug + Display + Send {
+    fn error_code(&self) -> ResultCode;
+}
+
+pub type NexResult<T> = Result<T, Box<dyn NexError>>;

--- a/nex-rs/src/result/nex_error.rs
+++ b/nex-rs/src/result/nex_error.rs
@@ -1,6 +1,9 @@
 use crate::nex_types::ResultCode;
 use std::fmt::{Debug, Display};
 
+/// A trait that represents a nex error.
+/// In the event of an error, [NexError::error_code] will be
+/// sent to the 3ds.
 pub trait NexError: Debug + Display + Send {
     fn error_code(&self) -> ResultCode;
 }

--- a/nex-rs/src/server/event_handler.rs
+++ b/nex-rs/src/server/event_handler.rs
@@ -1,27 +1,29 @@
 use crate::{
-    client::ClientConnection,
-    packet::PacketV1,
-    result::{Error as NexError, NexResult},
-    rmc::RMCRequest,
+    client::ClientConnection, packet::PacketV1, result::Error as NexError, rmc::RMCRequest,
+    server::ServerResult,
 };
 use async_trait::async_trait;
 
 #[async_trait]
 pub trait EventHandler {
-    async fn on_syn(&self, client: &mut ClientConnection, packet: &PacketV1) -> NexResult<()>;
-    async fn on_connect(&self, client: &mut ClientConnection, packet: &PacketV1) -> NexResult<()>;
-    async fn on_data(&self, client: &mut ClientConnection, packet: &PacketV1) -> NexResult<()>;
+    async fn on_syn(&self, client: &mut ClientConnection, packet: &PacketV1) -> ServerResult<()>;
+    async fn on_connect(
+        &self,
+        client: &mut ClientConnection,
+        packet: &PacketV1,
+    ) -> ServerResult<()>;
+    async fn on_data(&self, client: &mut ClientConnection, packet: &PacketV1) -> ServerResult<()>;
     async fn on_disconnect(
         &self,
         client: &mut ClientConnection,
         packet: &PacketV1,
-    ) -> NexResult<()>;
-    async fn on_ping(&self, client: &mut ClientConnection, packet: &PacketV1) -> NexResult<()>;
+    ) -> ServerResult<()>;
+    async fn on_ping(&self, client: &mut ClientConnection, packet: &PacketV1) -> ServerResult<()>;
 
     async fn on_rmc_request(
         &self,
         client: &mut ClientConnection,
         rmc_request: &RMCRequest,
-    ) -> NexResult<()>;
+    ) -> ServerResult<()>;
     async fn on_error(&self, error: NexError);
 }

--- a/nex-rs/src/server/event_handler.rs
+++ b/nex-rs/src/server/event_handler.rs
@@ -25,5 +25,5 @@ pub trait EventHandler {
         client: &mut ClientConnection,
         rmc_request: &RMCRequest,
     ) -> ServerResult<()>;
-    async fn on_error(&self, error: NexError);
+    async fn on_error(&self, error: &NexError);
 }

--- a/nex-rs/src/server/result.rs
+++ b/nex-rs/src/server/result.rs
@@ -1,3 +1,4 @@
+use crate::{client, crypto, packet};
 use snafu::Snafu;
 use std::net::SocketAddr;
 
@@ -22,6 +23,60 @@ pub enum Error {
         sequence_id: u16,
         fragment_id: usize,
     },
+    #[snafu(display(
+        "Packet error: {}",
+        error.to_string()
+    ))]
+    PacketError { error: packet::Error },
+    #[snafu(display(
+        "Crypt error: {}",
+        error.to_string()
+    ))]
+    CryptError { error: crypto::Error },
+    #[snafu(display(
+        "Client connection error: {}",
+        error.to_string()
+    ))]
+    ClientConectionError { error: client::Error },
+    #[snafu(display(
+        "IO Error: {}",
+        error.to_string()
+    ))]
+    IoError { error: no_std_io::Error },
+    #[snafu(display("Error: {}", message))]
+    Generic { message: String },
+}
+
+impl From<packet::Error> for Error {
+    fn from(error: packet::Error) -> Self {
+        Self::PacketError { error }
+    }
+}
+
+impl From<crypto::Error> for Error {
+    fn from(error: crypto::Error) -> Self {
+        Self::CryptError { error }
+    }
+}
+
+impl From<client::Error> for Error {
+    fn from(error: client::Error) -> Self {
+        Self::ClientConectionError { error }
+    }
+}
+
+impl From<no_std_io::Error> for Error {
+    fn from(error: no_std_io::Error) -> Self {
+        Self::IoError { error }
+    }
+}
+
+impl From<&str> for Error {
+    fn from(message: &str) -> Self {
+        Self::Generic {
+            message: message.to_string(),
+        }
+    }
 }
 
 pub type ServerResult<T> = Result<T, Error>;

--- a/nex-rs/src/server/server_trait.rs
+++ b/nex-rs/src/server/server_trait.rs
@@ -110,7 +110,7 @@ pub trait Server: EventHandler {
             let clone = Arc::clone(&server);
             tokio::spawn(async move {
                 if let Err(error) = clone.handle_socket_message(buf, peer).await {
-                    clone.on_error(error.into()).await;
+                    clone.on_error(&error.into()).await;
                 }
             });
         }


### PR DESCRIPTION
This PR has the implementor of each protocol trait specify an `Error` that implements `NexError`.  This allows custom errors to be used for all protocol traits that are compatible with `EventHandler::on_error`.